### PR TITLE
Resolves silently failing requests without ssh-key

### DIFF
--- a/tmpl/review.tmpl
+++ b/tmpl/review.tmpl
@@ -15,7 +15,7 @@ from port
 <code>{{.}}</code><br>
 {{ end }}
 </td></tr>
-<tr><td>SSH Public Key:</td><td><code>{{.Request.SshCertificateRequest.PublicKey}}</code></td></tr>
+<tr><td>SSH Public Key:</td><td>{{ if .Request.SshCertificateRequest }}<code>{{ .Request.SshCertificateRequest.PublicKey }}</code>{{ else }}do not sign key{{ end }}</td></tr>
 <tr><td>Vault:</td><td>{{ if .Request.VaultTokenRequest }}create token{{ else }}do not renew{{ end }}</td></tr>
 <tr><td>Kubernetes:</td><td>{{ if .Request.KubernetesCertificateRequest }}create certificate{{ else }}do not renew certificate{{ end }}</td></tr>
 <tr><td>VMware:</td><td>{{ if .Request.VmwareCertificateRequest }}create certificate{{ else }}do not renew certificate{{ end }}</td></tr>


### PR DESCRIPTION
Wraps sshcertificate request in an if statement on authservice. Instead
of silently failing authservice returns that it will not sign any
ssh-keys.

This resolves #1 